### PR TITLE
Fix race condition causing containers to fail to start. Fixes #6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Run:
 
 ```
-$ docker run --detach --net=host --cap-add=NET_ADMIN --cap-add=NET_RAW --volume /var/run/docker.sock:/var/run/docker.sock tozd/external-ip
+$ docker run --detach --net=host --cap-add=NET_ADMIN --cap-add=NET_RAW --volume /var/run/docker.sock:/var/run/docker.sock --volume /run/xtables.lock:/run/xtables.lock tozd/external-ip
 ```
 
 After that, if any other Docker container has an environment variable `EXTERNAL_IP` set, with an IP address to use for
@@ -10,3 +10,6 @@ containers external IP, iptables will be configured to route container's traffic
 A chain named `EXTERNAL_IP` is created in the `nat` table into which all the rules are added.
 And one more empty chain is created after this one for any additional custom rules you might want
 to add, named `AFTER_EXTERNAL_IP`.
+
+Please make sure `/run/xtables.lock` exists on the host before starting the container.
+If this file does not exist, Docker will incorrectly create it as a directory, which may cause issues both on the host and with the container.

--- a/dockergen/update-iptables.tmpl
+++ b/dockergen/update-iptables.tmpl
@@ -1,9 +1,9 @@
 # First create our chains if there are not yet there. In reverse order.
 for CHAIN in AFTER_EXTERNAL_IP EXTERNAL_IP; do
-    if ! iptables --numeric -t nat --list $CHAIN >/dev/null 2>&1; then
-        iptables -t nat -N $CHAIN
-        iptables -t nat -A $CHAIN -j RETURN
-        iptables -t nat -I POSTROUTING -j $CHAIN
+    if ! iptables -w --numeric -t nat --list $CHAIN >/dev/null 2>&1; then
+        iptables -w -t nat -N $CHAIN
+        iptables -w -t nat -A $CHAIN -j RETURN
+        iptables -w -t nat -I POSTROUTING -j $CHAIN
     fi
 done
 
@@ -11,12 +11,12 @@ done
     {{ if $externalIP }}
         # First we remove all existing entries.
         for line in $(iptables --line-numbers --numeric -t nat --list EXTERNAL_IP | awk '$7=="to:{{ $externalIP }}" {print $1}' | tac); do
-            iptables -t nat -D EXTERNAL_IP $line
+            iptables -w -t nat -D EXTERNAL_IP $line
         done
 
         {{ range $index, $container := $containersByExternalIP }}
             {{ range $index, $network := $container.Networks }}
-                iptables -t nat -I EXTERNAL_IP -s {{ $network.IP }} -j SNAT --to-source {{ $externalIP }}
+                iptables -w -t nat -I EXTERNAL_IP -s {{ $network.IP }} -j SNAT --to-source {{ $externalIP }}
             {{ end }}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
This change fixes host firewall race conditions causing containers to sometimes fail to start.
In order to avoid concurrent modification, iptables tracks locks in the file `/run/xtables.lock`.
In order for iptables inside a VM to respect the locking, it will need access to this file as well (https://github.com/moby/moby/issues/12547#issuecomment-306143160).

The downside of this implementation, as explained in above linked comment, is that, in some configurations, the lockfile may not exist when the container is started, and Docker will create it as a directory.
Sadly there's no reliable/non-hacky way to avoid this within the scope of this project that I know of, as any method to create this file would require root access, and the container user on the host is not likely to be root.